### PR TITLE
Update pkgdown site URL

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: http://ropensci.github.io/
+url: http://ropensci.github.io/epubr/
 
 template:
   params:


### PR DESCRIPTION
The url field for pkgdown needs to be the website full path.

See for example how it produced a broken [sitemap](https://ropensci.github.io/epubr/sitemap.xml).